### PR TITLE
Fix silent empty database dumps in Docker mode (masking exit codes through gzip pipeline)

### DIFF
--- a/backup-restore.sh
+++ b/backup-restore.sh
@@ -1077,12 +1077,22 @@ create_panel_db_dump() {
             fi
             
             local docker_error_log=$(mktemp)
-            if ! docker exec "remnawave-db" pg_dumpall -c -U "$DB_USER" 2>"$docker_error_log" | gzip -9 > "$dump_file"; then
+            docker exec "remnawave-db" pg_dump -c -U "$DB_USER" -d "$DB_NAME" 2>"$docker_error_log" | gzip -9 > "$dump_file"
+            local pg_dump_exit_code=${PIPESTATUS[0]}
+            
+            if [[ $pg_dump_exit_code -ne 0 ]]; then
                 LAST_DB_ERROR=$(cat "$docker_error_log" 2>/dev/null | head -5 | tr '\n' ' ')
                 rm -f "$docker_error_log"
                 return 1
             fi
             rm -f "$docker_error_log"
+            
+            local dump_size=$(stat -c%s "$dump_file" 2>/dev/null || stat -f%z "$dump_file" 2>/dev/null || echo "0")
+            if [[ "$dump_size" -lt 100 ]]; then
+                LAST_DB_ERROR="$(printf "$(t db_dump_small)" "$dump_size")"
+                print_message "ERROR" "$LAST_DB_ERROR"
+                return 1
+            fi
             ;;
         external)
             if [[ -z "$DB_HOST" ]]; then
@@ -1530,12 +1540,7 @@ create_backup() {
         exit 1
     fi
     
-    local DUMP_TYPE
-    if [[ "$DB_CONNECTION_TYPE" == "docker" ]]; then
-        DUMP_TYPE="dumpall"
-    else
-        DUMP_TYPE="dump"
-    fi
+    local DUMP_TYPE="dump"
     
     cat > "$BACKUP_DIR/backup_meta.info" <<METAEOF
 DUMP_TYPE="$DUMP_TYPE"


### PR DESCRIPTION
### Problem
When backing up PostgreSQL databases running inside Docker, the script executed the backup command via a pipeline to gzip:
`docker exec ... pg_dumpall | gzip -9 > "$dump_file"`

By default in Bash, if any command in a pipeline fails, the exit status of the pipeline is determined by the last command (which is `gzip`). If the database dump failed (e.g., container was down or the specific non-superuser had insufficient privileges for `pg_dumpall`), `gzip` still completed successfully on the empty stream (producing a 20-byte `.gz` file) and returned exit status 0. 

As a result, the script falsely reported a successful backup, leaving users with completely empty backups in case of DB failure.

### Solution
1. **Error Capturing:** Replaced pipeline-level checks with a direct `${PIPESTATUS[0]}` inspection. This correctly captures and reports if the `pg_dump` command fails.
2. **Size Validation:** Implemented an additional dump size check (must be > 100 bytes), mirroring the robust check already used in the `external` database mode.
3. **Database-specific dumps:** Replaced `pg_dumpall` with a database-specific `pg_dump -d "$DB_NAME"` targeting the panel DB. `pg_dumpall` requires superuser access, whereas `pg_dump` works flawlessly with non-superuser panel credentials.