### PR TITLE
fix: add export REQUESTS_CA_BUNDLE for current certs in aws cli

### DIFF
--- a/backup-restore.sh
+++ b/backup-restore.sh
@@ -3,6 +3,7 @@
 set -e
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:$PATH"
+export REQUESTS_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
 
 VERSION="3.2.4"
 INSTALL_DIR="/opt/rw-backup-restore"


### PR DESCRIPTION
# Problem

```
SSL validation failed for https://<bucket_name>.<domain>/?list-type=2&prefix=&delimiter=%2F&encoding-type=url [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain (_ssl.c:1000)
```

This error happens when i attempt connect to S3. This error happens because AWS CLI is supplied with own certs not contains current certs from CA.

# Solution

By adding `export REQUESTS_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"` to start of the script for using current certs of ca-certificates.
